### PR TITLE
PNP-12129 Enable identifying existing objects by UniqueEntity constraint

### DIFF
--- a/DependencyInjection/CompilerPass.php
+++ b/DependencyInjection/CompilerPass.php
@@ -21,13 +21,6 @@ class CompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-
-
-        if ($container->hasDefinition('jms_serializer.doctrine_object_constructor')) {
-            $container->getDefinition("jms_serializer.doctrine_object_constructor")
-                ->setClass(DoctrineObjectConstructor::class);
-        }
-
         if ($container->hasDefinition('fos_rest.converter.request_body')) {
             $container->getDefinition('fos_rest.converter.request_body')
                 ->setClass(RequestBodyParamConverter::class);

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,6 +13,13 @@ services:
     draw.request_deserializer:
         alias: fos_rest.converter.request_body
 
+    jms_serializer.doctrine_object_constructor:
+        class: Draw\DrawBundle\Serializer\Construction\DoctrineObjectConstructor
+        arguments:
+            - '@doctrine'
+            - '@jms_serializer.unserialize_object_constructor'
+            - '@validator'
+
     jms_serializer.object_constructor:
         alias: jms_serializer.doctrine_object_constructor
         public: false

--- a/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/Serializer/Construction/DoctrineObjectConstructor.php
@@ -89,7 +89,12 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
                 // Extract all UniqueEntity constraints check if all fields required by this constraint are set
                 foreach ($constraints as $index => $constraint) {
                     if ($constraint instanceof UniqueEntity) {
-                        foreach ($constraint->fields as $name) {
+                        if (is_string($constraint->fields)) {
+                            $fields[] = $constraint->fields;
+                        } else {
+                            $fields = $constraint->fields;
+                        }
+                        foreach ($fields as $name) {
                             if (!isset($data[$name])) {
                                 // We don't have some field in provided data to reliably use this constraint
                                 unset($constraints[$index]);

--- a/Serializer/Construction/DoctrineObjectConstructor.php
+++ b/Serializer/Construction/DoctrineObjectConstructor.php
@@ -3,10 +3,13 @@
 namespace Draw\DrawBundle\Serializer\Construction;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
 use JMS\Serializer\Construction\ObjectConstructorInterface;
 use JMS\Serializer\VisitorInterface;
 use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\DeserializationContext;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Doctrine object constructor for new (or existing) objects during deserialization.
@@ -15,17 +18,23 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
 {
     private $managerRegistry;
     private $fallbackConstructor;
+    private $validator;
 
     /**
      * Constructor.
      *
      * @param ManagerRegistry $managerRegistry Manager registry
      * @param ObjectConstructorInterface $fallbackConstructor Fallback object constructor
+     * @param ValidatorInterface $validator
      */
-    public function __construct(ManagerRegistry $managerRegistry, ObjectConstructorInterface $fallbackConstructor)
-    {
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        ObjectConstructorInterface $fallbackConstructor,
+        ValidatorInterface $validator
+    ) {
         $this->managerRegistry = $managerRegistry;
         $this->fallbackConstructor = $fallbackConstructor;
+        $this->validator = $validator;
     }
 
     /**
@@ -69,9 +78,50 @@ class DoctrineObjectConstructor implements ObjectConstructorInterface
 
         $classMetadata = $objectManager->getClassMetadata($class);
         $identifierList = array();
+        $validatorMetadata = $this->validator->getMetadataFor($class);
+        $constraints = $validatorMetadata->getConstraints();
 
         foreach ($classMetadata->getIdentifierFieldNames() as $name) {
             if (!isset($data[$name])) {
+
+                // If some identifier field is not set in received data, we can still reliably identify object if it has
+                // UniqueEntity constraint.
+                // Extract all UniqueEntity constraints check if all fields required by this constraint are set
+                foreach ($constraints as $index => $constraint) {
+                    if ($constraint instanceof UniqueEntity) {
+                        foreach ($constraint->fields as $name) {
+                            if (!isset($data[$name])) {
+                                // We don't have some field in provided data to reliably use this constraint
+                                unset($constraints[$index]);
+                                break;
+                            }
+                        }
+                    } else {
+                        // Unset non UniqueEntity constraints
+                        unset($constraints[$index]);
+                    }
+                }
+
+                // Only those UniqueEntity constraints, which we have all necessary fields for, should be left here
+                if (count($constraints) === 0) {
+                    return null;
+                }
+
+                // Try to find object based on remaining UniqueEntity constraints
+                foreach ($constraints as $constraint) {
+                    $uniqueFieldsList = [];
+                    foreach ($constraint->fields as $fieldName) {
+                        $uniqueFieldsList[$fieldName] = $data[$fieldName];
+                    }
+                    $object = $objectManager->getRepository($class)->findOneBy($uniqueFieldsList);
+                    // If object is found, no need to check other constraints, just return it
+                    if ($object !== null) {
+                        return $object;
+                    }
+
+                }
+
+                // If we couldn't find object using Unique constraints, we can't reliably identify object
                 return null;
             }
 


### PR DESCRIPTION
Can't inject validator in CompilerPass with ->addArgument($container->get('validator)) (same thing with addMethodCall).
Container building process fails in that case, somewhere at creating some logger service as I recall.
So I had to completely redefine the service.

New code will fallback to loading object based on UniqueEntity constraint, if identifier is missing. It also supports multiple UniqueEntity constraints per Entity, and compound UniqueEntity constraints (with multiple fields)